### PR TITLE
refactor: use browser-resolve for module resolving

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "acorn": "3.2.0",
     "ast-types": "0.8.16",
     "astring": "0.6.1",
+    "browser-resolve": "1.11.2",
     "minimist": "1.2.0",
     "node-libs-browser": "1.0.0"
   },

--- a/src/module-path.ts
+++ b/src/module-path.ts
@@ -2,6 +2,34 @@ import { IHost, DefaultHost } from './host';
 import { sync as browserResolveSync } from 'browser-resolve';
 import * as nodeCoreLibs from 'node-libs-browser';
 
+interface IPackage {
+  main: string;
+  browser?: string;
+  'jsnext:main'?: string;
+}
+
+/**
+ * Return package data with normalized main fields
+ * Precedence: browser, jsnext:main, main
+ *
+ * @param pkg Package data
+ */
+function normalizePackage(pkg: IPackage) {
+  // .browser, use package data as is
+  if ('browser' in pkg) {
+    return pkg;
+  }
+
+  // no .browser, .jsnext:main, use jsnext:main by aliasing to .main
+  if ('jsnext:main' in pkg) {
+    pkg.main = pkg['jsnext:main'];
+    return pkg;
+  }
+
+  // use .main
+  return pkg;
+}
+
 /**
  * Return a resolved module path
  *
@@ -13,14 +41,7 @@ export function getModulePath(filename: string, importIdentifier: string, host: 
   return browserResolveSync(importIdentifier, {
     filename: filename,
     modules: nodeCoreLibs,
-    packageFilter: pkg => {
-      // If the browser field is not defined, use jsnext:main instead
-      if ('browser' in pkg === false && 'jsnext:main' in pkg) {
-        pkg.browser = pkg['jsnext:main'];
-      }
-
-      return pkg;
-    },
+    packageFilter: normalizePackage,
     readFileSync: path => new Buffer(host.readFile(path)),
     isFile: filePath => host.fileExists(filePath) && host.isFile(filePath)
   });

--- a/src/module-path.ts
+++ b/src/module-path.ts
@@ -1,88 +1,28 @@
 import { IHost, DefaultHost } from './host';
+import * as fs from 'fs';
+import * as browserResolve from 'browser-resolve';
 import * as nodeCoreLibs from 'node-libs-browser';
 
 /**
- * node resolve algorithms with some specialities:
- * 
- * * package.json entries are considered in this order: 'jsnext:main', 'browser', 'main'
- * * node core libraries are resolved against node-libs-browser (from webpack)
+ * Return a resolved module path
+ *
+ * @param filename Path to file from where importPath is resolved
+ * @param importIdentifier Identifier to resolve from filename
+ * @param [host]
  */
-export function getModulePath(currentModule: string, importPath: string, host: IHost = new DefaultHost()): string {
-  function notFound(): void {
-    throw new Error(`Module ${importPath} not found`);
-  }
-  function resolveAsFile(file: string): string {
-    if (host.fileExists(file) && host.isFile(file)) {
-      return file;
-    }
-    const filePath = file + '.js';
-    if (host.fileExists(filePath) && host.isFile(filePath)) {
-      return filePath;
-    }
-  }
-  function resolveAsDirectory(dir: string): string {
-    const pkgFile = host.joinPath(dir, 'package.json');
-    if (host.fileExists(pkgFile) && host.isFile(pkgFile)) {
-      const pkg = JSON.parse(host.readFile(pkgFile).toString());
-      const main = pkg['jsnext:main'] || (typeof pkg.browser === 'string' ? pkg.browser : undefined) || pkg.main;
-      if (main) {
-        const result = resolveAsFile(host.joinPath(dir, main));
-        if (result) {
-          return result;
-        }
+export function getModulePath(filename: string, importIdentifier: string, host: IHost = new DefaultHost()): string {
+  return browserResolve.sync(importIdentifier, {
+    filename: filename,
+    modules: nodeCoreLibs,
+    packageFilter: pkg => {
+      // If the browser field is not defined, use jsnext:main instead
+      if ('browser' in pkg === false && 'jsnext:main' in pkg) {
+        pkg.browser = pkg['jsnext:main'];
       }
-    }
-    const index = host.joinPath(dir, 'index.js');
-    if (host.fileExists(index) && host.isFile(index)) {
-      return index;
-    }
-  }
-  function resolveAsFileOrDirectory(inputPath: string): string {
-    const result = resolveAsFile(inputPath);
-    if (result) {
-      return result;
-    }
-    return resolveAsDirectory(inputPath);
-  }
-  function resolveAsNodeModule(current: string, imported: string): string {
-    function getNodeModulesPaths(start: string): string[] {
-      const parts = start.split(host.pathSep);
-      let i = parts.length - 1;
-      const dirs: string[] = [];
-      while (i > -1) {
-        if (parts[i] !== 'node_modules') {
-          dirs.push(host.joinPath(parts.slice(0, i + 1).join(host.pathSep), 'node_modules'));
-        }
-        i--;
-      }
-      return dirs;
-    }
-    const dirs = getNodeModulesPaths(current);
-    for (let i = 0, n = dirs.length; i < n; i++) {
-      const result = resolveAsFileOrDirectory(host.joinPath(dirs[i], imported));
-      if (result) {
-        return result;
-      }
-    }
-  }
 
-  if (importPath.charAt(0) === '.' || importPath.charAt(0) === '/') {
-    const fileOrPath = importPath.charAt(0) === '/'
-      ? importPath
-      : host.joinPath(host.dirname(currentModule), importPath);
-    const result = resolveAsFileOrDirectory(fileOrPath);
-    if (result) {
-      return result;
-    }
-  }
-  const result = resolveAsNodeModule(currentModule, importPath);
-  if (result) {
-    return result;
-  }
-  // Check for node core modules
-  const coreLib = (nodeCoreLibs as any)[importPath];
-  if (coreLib) {
-    return coreLib;
-  }
-  notFound();
+      return pkg;
+    },
+    readFileSync: path => new Buffer(host.readFile(path)),
+    isFile: filePath => host.fileExists(filePath) && host.isFile(filePath)
+  });
 }

--- a/src/module-path.ts
+++ b/src/module-path.ts
@@ -1,6 +1,5 @@
 import { IHost, DefaultHost } from './host';
-import * as fs from 'fs';
-import * as browserResolve from 'browser-resolve';
+import { sync as browserResolveSync } from 'browser-resolve';
 import * as nodeCoreLibs from 'node-libs-browser';
 
 /**
@@ -11,7 +10,7 @@ import * as nodeCoreLibs from 'node-libs-browser';
  * @param [host]
  */
 export function getModulePath(filename: string, importIdentifier: string, host: IHost = new DefaultHost()): string {
-  return browserResolve.sync(importIdentifier, {
+  return browserResolveSync(importIdentifier, {
     filename: filename,
     modules: nodeCoreLibs,
     packageFilter: pkg => {

--- a/src/modules.ts
+++ b/src/modules.ts
@@ -1,4 +1,4 @@
-import * as path from 'path';
+import { resolve } from 'path';
 import { parse } from 'acorn';
 
 import { IHost } from './host';
@@ -77,7 +77,7 @@ function createModuleWrapper(name: string, moduleAst: ESTree.Program): IWrappedM
 
 export function wrapModule(modulePath: string, modules: (ESTree.Expression | ESTree.SpreadElement)[],
     host: IHost, plugins: any = defaultPlugins): void {
-  const resolvedPath = path.resolve(modulePath);
+  const resolvedPath = resolve(modulePath);
   const moduleName = resolvedPath.replace(/\.js$/, '');
   // Short cut for already processed imports
   if (isModuleReadyOrInProgress(moduleName)) {

--- a/src/modules.ts
+++ b/src/modules.ts
@@ -77,7 +77,8 @@ function createModuleWrapper(name: string, moduleAst: ESTree.Program): IWrappedM
 
 export function wrapModule(modulePath: string, modules: (ESTree.Expression | ESTree.SpreadElement)[],
     host: IHost, plugins: any = defaultPlugins): void {
-  const moduleName = path.resolve(modulePath).replace(/\.js$/, '');
+  const resolvedPath = path.resolve(modulePath);
+  const moduleName = resolvedPath.replace(/\.js$/, '');
   // Short cut for already processed imports
   if (isModuleReadyOrInProgress(moduleName)) {
     return;
@@ -85,7 +86,7 @@ export function wrapModule(modulePath: string, modules: (ESTree.Expression | EST
   // Prefill module indices
   getModuleIndex(moduleName);
   wrappedModules[moduleName].inProcess = true;
-  const moduleAst = parse(host.readFile(modulePath).toString(), {
+  const moduleAst = parse(host.readFile(resolvedPath).toString(), {
     ecmaVersion: 7,
     sourceType: 'module',
     locations: true,

--- a/src/plugins/es6-import.ts
+++ b/src/plugins/es6-import.ts
@@ -9,8 +9,8 @@ export function rewriteImportDeclaration(program: ESTree.Program, moduleName: st
   visit(program, {
     visitImportDeclaration: function(path: IPath<ESTree.ImportDeclaration>): boolean {
       const source = path.node.source;
+
       if (n.Literal.check(source)) {
-        // e.g. import { a as b, c } from './dep';
         const importModule = getModulePath(moduleName, source.value as string, host);
         const importModuleIndex = getModuleIndex(importModule);
 
@@ -18,6 +18,7 @@ export function rewriteImportDeclaration(program: ESTree.Program, moduleName: st
         const tempIdentifier = b.identifier(`__import${importModuleIndex}_${loc(path.node.loc.start)}`);
         const imports = path.node.specifiers.map((specifier) => {
           if (n.ImportSpecifier.check(specifier)) {
+            // e.g. import { a as b, c } from './dep';
             return b.variableDeclarator(
               b.identifier(specifier.local.name),
               b.memberExpression(
@@ -31,6 +32,7 @@ export function rewriteImportDeclaration(program: ESTree.Program, moduleName: st
               )
             );
           } else if (n.ImportDefaultSpecifier.check(specifier)) {
+            // e.g. import dep from './dep';
             return b.variableDeclarator(
               b.identifier(specifier.local.name),
               b.memberExpression(
@@ -44,6 +46,7 @@ export function rewriteImportDeclaration(program: ESTree.Program, moduleName: st
               )
             );
           } else if (n.ImportNamespaceSpecifier.check(specifier)) {
+            // e.g. import * as dep from './dep';
             return b.variableDeclarator(
               b.identifier(specifier.local.name),
               b.memberExpression(

--- a/test/helper.ts
+++ b/test/helper.ts
@@ -1,4 +1,4 @@
-import { join, dirname, resolve } from 'path';
+import { dirname, join, resolve } from 'path';
 import { runInNewContext } from 'vm';
 import { parse, IParseOptions } from 'acorn';
 import * as astringNode from 'astring';

--- a/test/helper.ts
+++ b/test/helper.ts
@@ -1,4 +1,4 @@
-import { join, dirname } from 'path';
+import { join, dirname, resolve } from 'path';
 import { runInNewContext } from 'vm';
 import { parse, IParseOptions } from 'acorn';
 import * as astringNode from 'astring';
@@ -9,17 +9,49 @@ import { IHost } from '../src/host';
 export class HostMock implements IHost {
   public pathSep: string = '/';
 
-  constructor(public files: {[path: string]: string}) {}
+  private basePath: string = process.cwd()
+  private files: any = {};
 
-  public fileExists(path: string): boolean {
-    return Object.keys(this.files).indexOf(path) > -1;
-  };
-  public isFile(path: string): boolean {
-    return Object.keys(this.files).indexOf(path) > -1;
+  constructor(files: {[path: string]: string}, basePath: string = process.cwd()) {
+    this.fileExists = this.fileExists.bind(this);
+    this.isFile = this.isFile.bind(this);
+    this.readFile = this.readFile.bind(this);
+    this.joinPath = this.joinPath.bind(this);
+    this.dirname = this.dirname.bind(this);
+
+    this.basePath = basePath;
+
+    this.files = Object
+      .keys(files)
+      .reduce((registry: any, propertyName: string) => {
+        const resolved = resolve(this.basePath, propertyName);
+        registry[resolved] = files[propertyName];
+        return registry;
+      }, {});
   }
-  public readFile(path: string): string { return this.files[path]; };
-  public joinPath(...paths: string[]): string { return join(...paths); };
-  public dirname(path: string): string { return dirname(path); };
+
+  public fileExists(filePath: string): boolean {
+    return filePath in this.files;
+  }
+
+  public isFile(filePath: string): boolean {
+    return filePath in this.files;
+  }
+
+  public readFile(filePath: string): string {
+    if (this.fileExists(filePath)) {
+      return this.files[filePath];
+    }
+    throw new Error(`ENOENT: Could not read file ${filePath} from HostMock fs. Available files: ${Object.keys(this.files)}`);
+  }
+
+  public joinPath(...paths: string[]): string {
+    return join(...paths);
+  }
+
+  public dirname(filePath: string): string {
+    return dirname(filePath);
+  }
 }
 
 const acornOptions: IParseOptions = {

--- a/test/module-path-test.ts
+++ b/test/module-path-test.ts
@@ -1,3 +1,4 @@
+import * as path from 'path';
 import test from 'ava';
 
 import { HostMock } from './helper';
@@ -12,14 +13,14 @@ test('getModulePath should resolve an existing relative file', t => {
   const host = new HostMock({
     'some/else': ''
   });
-  t.deepEqual(getModulePath('some/where', './else', host), 'some/else');
+  t.is(getModulePath('some/where', './else', host), path.resolve(process.cwd(), 'some/else'));
 });
 
 test('getModulePath should resolve a relative file while adding .js', t => {
   const host = new HostMock({
     'some/else.js': ''
   });
-  t.deepEqual(getModulePath('some/where', './else', host), 'some/else.js');
+  t.is(getModulePath('some/where', './else', host), path.resolve(process.cwd(), 'some/else.js'));
 });
 
 test('getModulePath should resolve a relative directory with package.json and main', t => {
@@ -27,19 +28,47 @@ test('getModulePath should resolve a relative directory with package.json and ma
     'some/dir/package.json': '{"main": "./main.js"}',
     'some/dir/main.js': ''
   });
-  t.deepEqual(getModulePath('some/where', './dir', host), 'some/dir/main.js');
+  t.is(getModulePath('some/where', './dir', host), path.resolve(process.cwd(), 'some/dir/main.js'));
+});
+
+test('getModulePath should resolve browser field correctly', t => {
+  const host = new HostMock({
+    'some/dir/package.json': '{"browser": "./browser.js"}',
+    'some/dir/main.js': '',
+    'some/dir/browser.js': ''
+  });
+  t.is(getModulePath('some/where', './dir', host), path.resolve(process.cwd(), 'some/dir/browser.js'));
+});
+
+test('getModulePath should resolve jsnext:main field correctly', t => {
+  const host = new HostMock({
+    'some/dir/package.json': '{"jsnext:main": "./jsnext.js"}',
+    'some/dir/jsnext.js': '',
+    'some/dir/main.js': ''
+  });
+  t.is(getModulePath('some/where', './dir', host), path.resolve(process.cwd(), 'some/dir/jsnext.js'));
+});
+
+test('getModulePath should resolve browser, jsnext:main and main in correct precedence', t => {
+  const host = new HostMock({
+    'some/dir/package.json': '{"browser": "./browser", "jsnext:main": "./jsnext.js", "main": "./main.js"}',
+    'some/dir/browser.js': '',
+    'some/dir/jsnext.js': '',
+    'some/dir/main.js': ''
+  });
+  t.is(getModulePath('some/where', './dir', host), path.resolve(process.cwd(), 'some/dir/browser.js'));
 });
 
 test('getModulePath should resolve a relative directory without package.json but index.js', t => {
   const host = new HostMock({
     'some/dir/index.js': ''
   });
-  t.deepEqual(getModulePath('some/where', './dir', host), 'some/dir/index.js');
+  t.deepEqual(getModulePath('some/where', './dir', host), path.resolve(process.cwd(), 'some/dir/index.js'));
 });
 
 test('getModulePath should resolve from node_modules', t => {
   const host = new HostMock({
     'dir/node_modules/mod/index.js': ''
   });
-  t.deepEqual(getModulePath('dir/some/where', 'mod', host), 'dir/node_modules/mod/index.js');
+  t.deepEqual(getModulePath('dir/some/where', 'mod', host), path.resolve(process.cwd(), 'dir/node_modules/mod/index.js'));
 });

--- a/test/plugins/es6-import-test.ts
+++ b/test/plugins/es6-import-test.ts
@@ -1,0 +1,107 @@
+import test from 'ava';
+import { stripIndent } from 'common-tags';
+import { HostMock, virtualModule, parseAndProcess } from '../helper';
+import { IHost } from '../../src/host';
+
+import { reset } from '../../src/modules';
+import { rewriteImportDeclaration } from '../../src/plugins/es6-import';
+
+function rewriteImports(input: string, files: any = {}) {
+  const host = new HostMock(files);
+
+  return parseAndProcess(input, ast => {
+    return rewriteImportDeclaration(ast, 'name', [], host);
+  });
+}
+
+function executeImports(input: string, files: any = {}, settings: any = {}) {
+  const processed = rewriteImports(input, files);
+  return virtualModule(processed, settings);
+}
+
+test.beforeEach(reset);
+
+test('es6-import plugin should rewrite import specifiers correctly', t => {
+  const input = stripIndent`
+    import {foo} from './bar';
+    import {bar as baz} from './bar';
+    import {baz as foobar, foobar as baz} from './bar';
+    module.exports = {
+      foo: foo,
+      foobar: foobar,
+      baz: baz
+    };
+  `;
+
+  const exported = {
+    exports: {
+      foo: 'foo',
+      baz: 'baz',
+      foobar: 'foobar'
+    }
+  };
+
+  const expected = {
+    foo: 'foo',
+    baz: 'foobar',
+    foobar: 'baz'
+  };
+
+  const actual = executeImports(input, {
+    './bar.js': ''
+  }, {
+    modules: [() => exported]
+  });
+
+  t.deepEqual(actual, expected);
+});
+
+
+test('es6-import plugin should rewrite default import specifiers correctly', t => {
+  const input = stripIndent`
+    import foo from './bar';
+    module.exports = foo;
+  `;
+
+  const exported = {
+    exports: {
+      default: {
+        foo: 'foo'
+      }
+    }
+  };
+
+  const expected = exported.exports.default;
+
+  const actual = executeImports(input, {
+    './bar.js': ''
+  }, {
+    modules: [() => exported]
+  });
+
+  t.deepEqual(actual, expected);
+});
+
+test('es6-import plugin should rewrite namespace import specifiers correctly', t => {
+  const input = stripIndent`
+    import * as foo from './bar';
+    module.exports = foo;
+  `;
+
+  const exported = {
+    exports: {
+      foo: 'foo',
+      bar: 'bar'
+    }
+  };
+
+  const expected = exported.exports;
+
+  const actual = executeImports(input, {
+    './bar.js': ''
+  }, {
+    modules: [() => exported]
+  });
+
+  t.deepEqual(actual, expected);
+});

--- a/typings/browser-resolve/browser-resolve.d.ts
+++ b/typings/browser-resolve/browser-resolve.d.ts
@@ -1,0 +1,54 @@
+declare module 'browser-resolve' {
+  import * as resolve from 'resolve';
+
+  /**
+   * Callback invoked when resolving asynchronously
+   *
+   * @param error
+   * @param resolved Absolute path to resolved identifier
+   */
+  type resolveCallback = (err: Error, resolved: string) => void;
+
+  /**
+   * Resolve a module path and call cb(err, path [, pkg])
+   *
+   * @param id Identifier to resolve
+   * @param callback
+   */
+  function browserResolve(id: string, cb: resolveCallback): void;
+
+  /**
+   * Resolve a module path and call cb(err, path [, pkg])
+   *
+   * @param id Identifier to resolve
+   * @param options Options to use for resolving, optional.
+   * @param callback
+   */
+  function browserResolve(id: string, opts: browserResolve.AsyncOpts, cb: resolveCallback): void;
+
+  /**
+   * Returns a module path
+   *
+   * @param id Identifier to resolve
+   * @param options Options to use for resolving, optional.
+   */
+  function browserResolveSync(id: string, opts: browserResolve.SyncOpts): string;
+
+  namespace browserResolve {
+    interface Opts {
+      // the 'browser' property to use from package.json (defaults to 'browser')
+      browser?: string;
+      // the calling filename where the require() call originated (in the source)
+      filename?: string;
+      // modules object with id to path mappings to consult before doing manual resolution (use to provide core modules)
+      modules?: any;
+    }
+
+    export interface AsyncOpts extends resolve.AsyncOpts, Opts {}
+    export interface SyncOpts extends resolve.SyncOpts, Opts {}
+
+    export var sync: typeof browserResolveSync;
+  }
+
+  export = browserResolve
+}

--- a/typings/resolve/resolve.d.ts
+++ b/typings/resolve/resolve.d.ts
@@ -1,0 +1,95 @@
+declare module 'resolve' {
+  /**
+   * Callback invoked when resolving asynchronously
+   *
+   * @param error
+   * @param resolved Absolute path to resolved identifier
+   */
+  type resolveCallback = (err: Error, resolved: string) => void;
+
+  /**
+   * Callback invoked when checking if a file exists
+   *
+   * @param error
+   * @param isFile If the given file exists
+   */
+  type isFileCallback = (err: Error, isFile: boolean) => void;
+
+  /**
+   * Callback invoked when reading a file
+   *
+   * @param error
+   * @param isFile If the given file exists
+   */
+  type readFileCallback = (err: Error, file: Buffer) => void;
+
+  /**
+   * Asynchronously resolve the module path string id into cb(err, res [, pkg]), where pkg (if defined) is the data from package.json
+   *
+   * @param id Identifier to resolve
+   * @param callback
+   */
+  function resolve(id: string, cb: resolveCallback): void;
+
+  /**
+   * Asynchronously resolve the module path string id into cb(err, res [, pkg]), where pkg (if defined) is the data from package.json
+   *
+   * @param id Identifier to resolve
+   * @param options Options to use for resolving, optional.
+   * @param callback
+   */
+  function resolve(id: string, opts: resolve.AsyncOpts, cb: resolveCallback): void;
+
+  /**
+   * Synchronously resolve the module path string id, returning the result and throwing an error when id can't be resolved.
+   *
+   * @param id Identifier to resolve
+   * @param options Options to use for resolving, optional.
+   */
+  function resolveSync(id: string, opts: resolve.SyncOpts): string;
+
+  /**
+   * Return whether a package is in core
+   *
+   * @param id
+   */
+  function resolveIsCore(id: string): boolean;
+
+  namespace resolve {
+    interface Opts {
+      // directory to begin resolving from (defaults to __dirname)
+      basedir?: string;
+      // package.json data applicable to the module being loaded
+      package?: any;
+      // array of file extensions to search in order (defaults to ['.js'])
+      extensions?: string|string[];
+      // transform the parsed package.json contents before looking at the "main" field
+      packageFilter?: (pkg: any, pkgfile: string) => any;
+      // transform a path within a package
+      pathFilter?: (pkg: any, path: string, relativePath: string) => string;
+      // require.paths array to use if nothing is found on the normal node_modules recursive walk (probably don't use this)
+      paths?: string|string[];
+      // directory (or directories) in which to recursively look for modules. (default to 'node_modules')
+      moduleDirectory?: string|string[]
+    }
+    
+    export interface AsyncOpts extends Opts {
+      // how to read files asynchronously (defaults to fs.readFile)
+      readFile?: (file: string, cb: readFileCallback) => void;
+      // function to asynchronously test whether a file exists
+      isFile?: (file: string, cb: isFileCallback) => void;
+    }
+
+    export interface SyncOpts extends Opts {
+      // how to read files synchronously (defaults to fs.readFileSync)
+      readFileSync?: (file: string) => Buffer;
+      // function to synchronously test whether a file exists
+      isFile?: (file: string) => boolean;
+    }
+
+    export var sync: typeof resolveSync;
+    export var isCore: typeof resolveIsCore;
+  }
+  
+  export = resolve;
+}


### PR DESCRIPTION
-  superseeds #8
-  adds resolve typings
-  adds browser-resolve typings
-  adds test cases for browser field precedence chain
-  refactors mock host to handle absolute paths

---

Needs (unrelated) #14 to pass the coverage tests. 
