### PR TITLE
chore: Adds linter step to ci build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
 node_js:
-  - "4.2.0"
+  - "4"
+before_script: 'npm run linter'
 after_script: 'npm run coverage && cat ./coverage/lcov.info | ./node_modules/.bin/coveralls'

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "#postinstall": "Remove bundled typings to use patched version without Promise support",
     "postinstall": "rimraf node_modules/ava/index.d.ts",
     "clean": "rimraf dist",
+    "linter": "tslint 'src/**/*.ts'",
     "prebuild": "npm run clean",
     "build": "tsc --sourceMap",
     "build:watch": "tsc --sourceMap --watch",

--- a/src/module-path.ts
+++ b/src/module-path.ts
@@ -14,7 +14,7 @@ interface IPackage {
  *
  * @param pkg Package data
  */
-function normalizePackage(pkg: IPackage) {
+function normalizePackage(pkg: IPackage): IPackage {
   // .browser, use package data as is
   if ('browser' in pkg) {
     return pkg;
@@ -42,7 +42,7 @@ export function getModulePath(filename: string, importIdentifier: string, host: 
     filename: filename,
     modules: nodeCoreLibs,
     packageFilter: normalizePackage,
-    readFileSync: path => new Buffer(host.readFile(path)),
-    isFile: filePath => host.fileExists(filePath) && host.isFile(filePath)
+    readFileSync: (path: string): Buffer => new Buffer(host.readFile(path)),
+    isFile: (filePath: string): boolean => host.fileExists(filePath) && host.isFile(filePath)
   });
 }


### PR DESCRIPTION
Adds an enforced linter run to the ci build. This is optional during development to not bug developers too much while hacking.
