### PR TITLE
feat: Maintain a working queue to schedule bundling

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import * as path from 'path';
+import { join } from 'path';
 import * as minimistNode from 'minimist';
 const minimist: typeof minimistNode = minimistNode;
 import { parse } from 'acorn';
@@ -6,6 +6,7 @@ import * as astringNode from 'astring';
 const astring: typeof astringNode = astringNode as any;
 
 import { DefaultHost } from './host';
+import { getModulePath } from './module-path';
 import { enqueueModule, bundleNextModule } from './modules';
 
 function getModules(ast: ESTree.Program): ESTree.ArrayExpression {
@@ -25,7 +26,8 @@ function bundle(argv: minimistNode.ParsedArgs): string {
   `;
   const paeckchenAst = parse(paeckchenSource);
   const modules = getModules(paeckchenAst).elements;
-  enqueueModule(argv['entry']);
+  const absoluteEntryPath = join(process.cwd(), argv['entry']);
+  enqueueModule(getModulePath('.', absoluteEntryPath, host));
   while (bundleNextModule(modules, host)) {
     process.stderr.write('.');
   }
@@ -39,7 +41,7 @@ const argv = minimist(process.argv.slice(2), {
   string: ['config', 'entry'],
   boolean: ['watch'],
   default: {
-    config: path.join(__dirname, 'paeckchen.config.js'),
+    config: join(__dirname, 'paeckchen.config.js'),
     watch: false
   }
 });

--- a/src/module-path.ts
+++ b/src/module-path.ts
@@ -1,4 +1,4 @@
-import { IHost, DefaultHost } from './host';
+import { IHost } from './host';
 import { sync as browserResolveSync } from 'browser-resolve';
 import * as nodeCoreLibs from 'node-libs-browser';
 
@@ -37,7 +37,7 @@ function normalizePackage(pkg: IPackage): IPackage {
  * @param importIdentifier Identifier to resolve from filename
  * @param [host]
  */
-export function getModulePath(filename: string, importIdentifier: string, host: IHost = new DefaultHost()): string {
+export function getModulePath(filename: string, importIdentifier: string, host: IHost): string {
   return browserResolveSync(importIdentifier, {
     filename: filename,
     modules: nodeCoreLibs,

--- a/src/modules.ts
+++ b/src/modules.ts
@@ -35,8 +35,9 @@ export function getModuleIndex(name: string): number {
 }
 
 export function updateModule(name: string): void {
-  if (wrappedModules[name]) {
-    wrappedModules[name].ast = undefined;
+  const moduleName = getModuleName(name);
+  if (wrappedModules[moduleName]) {
+    wrappedModules[moduleName].ast = undefined;
   }
 }
 

--- a/src/modules.ts
+++ b/src/modules.ts
@@ -1,4 +1,3 @@
-import { resolve } from 'path';
 import { parse } from 'acorn';
 
 import { IHost } from './host';
@@ -77,7 +76,7 @@ function createModuleWrapper(name: string, moduleAst: ESTree.Program): IWrappedM
 
 const moduleBundleQueue: string[] = [];
 export function enqueueModule(modulePath: string): void {
-  moduleBundleQueue.push(resolve(modulePath));
+  moduleBundleQueue.push(modulePath);
 }
 
 export function bundleNextModule(modules: (ESTree.Expression | ESTree.SpreadElement)[],
@@ -92,8 +91,7 @@ export function bundleNextModule(modules: (ESTree.Expression | ESTree.SpreadElem
 
 function wrapModule(modulePath: string, modules: (ESTree.Expression | ESTree.SpreadElement)[],
     host: IHost, plugins: any = defaultPlugins): void {
-  const resolvedPath = resolve(modulePath);
-  const moduleName = resolvedPath.replace(/\.js$/, '');
+  const moduleName = modulePath.replace(/\.js$/, '');
   // Short cut for already processed imports
   if (isModuleReadyOrInProgress(moduleName)) {
     return;
@@ -101,7 +99,7 @@ function wrapModule(modulePath: string, modules: (ESTree.Expression | ESTree.Spr
   // Prefill module indices
   getModuleIndex(moduleName);
   wrappedModules[moduleName].inProcess = true;
-  const moduleAst = parse(host.readFile(resolvedPath).toString(), {
+  const moduleAst = parse(host.readFile(modulePath).toString(), {
     ecmaVersion: 7,
     sourceType: 'module',
     locations: true,
@@ -110,7 +108,7 @@ function wrapModule(modulePath: string, modules: (ESTree.Expression | ESTree.Spr
   });
 
   Object.keys(plugins).forEach(plugin => {
-    plugins[plugin](moduleAst, moduleName, host);
+    plugins[plugin](moduleAst, modulePath, host);
   });
 
   const wrappedModule = createModuleWrapper(moduleName, moduleAst);

--- a/src/plugins/commonjs.ts
+++ b/src/plugins/commonjs.ts
@@ -1,11 +1,10 @@
 import { visit, builders as b, namedTypes as n, IPath } from 'ast-types';
 
-import { getModuleIndex, wrapModule } from '../modules';
+import { getModuleIndex, enqueueModule } from '../modules';
 import { getModulePath } from '../module-path';
 import { IHost } from '../host';
 
-export function rewriteRequireStatements(program: ESTree.Program, moduleName: string,
-    modules: (ESTree.Expression | ESTree.SpreadElement)[], host: IHost): void {
+export function rewriteRequireStatements(program: ESTree.Program, moduleName: string, host: IHost): void {
   visit(program, {
     visitCallExpression(path: IPath<ESTree.CallExpression>): boolean {
       const callee = path.node.callee;
@@ -31,7 +30,7 @@ export function rewriteRequireStatements(program: ESTree.Program, moduleName: st
             )
           );
 
-          wrapModule(modulePath, modules, host);
+          enqueueModule(modulePath);
         }
       }
       return false;

--- a/src/plugins/commonjs.ts
+++ b/src/plugins/commonjs.ts
@@ -4,7 +4,7 @@ import { getModuleIndex, enqueueModule } from '../modules';
 import { getModulePath } from '../module-path';
 import { IHost } from '../host';
 
-export function rewriteRequireStatements(program: ESTree.Program, moduleName: string, host: IHost): void {
+export function rewriteRequireStatements(program: ESTree.Program, currentModule: string, host: IHost): void {
   visit(program, {
     visitCallExpression(path: IPath<ESTree.CallExpression>): boolean {
       const callee = path.node.callee;
@@ -12,7 +12,7 @@ export function rewriteRequireStatements(program: ESTree.Program, moduleName: st
       if (n.Identifier.check(callee) && callee.name === 'require') {
         const importPath = path.node.arguments[0];
         if (n.Literal.check(importPath)) {
-          const modulePath = getModulePath(moduleName, (importPath as ESTree.Literal).value.toString(), host);
+          const modulePath = getModulePath(currentModule, (importPath as ESTree.Literal).value.toString(), host);
           const moduleIndex = getModuleIndex(modulePath);
 
           path.replace(

--- a/src/plugins/es6-export.ts
+++ b/src/plugins/es6-export.ts
@@ -1,6 +1,6 @@
 import { visit, builders as b, namedTypes as n, IPath } from 'ast-types';
 
-import { getModuleIndex, wrapModule } from '../modules';
+import { getModuleIndex, enqueueModule } from '../modules';
 import { getModulePath } from '../module-path';
 import { IHost } from '../host';
 
@@ -101,8 +101,7 @@ function exportAllKeys(identifier: ESTree.Identifier): ESTree.ExpressionStatemen
   );
 }
 
-export function rewriteExportNamedDeclaration(program: ESTree.Program, moduleName: string,
-  modules: (ESTree.Expression | ESTree.SpreadElement)[], host: IHost): void {
+export function rewriteExportNamedDeclaration(program: ESTree.Program, moduleName: string, host: IHost): void {
   visit(program, {
     visitExportAllDeclaration: function(path: IPath<ESTree.ExportAllDeclaration>): boolean {
       // e.g. export * from './a';
@@ -117,7 +116,7 @@ export function rewriteExportNamedDeclaration(program: ESTree.Program, moduleNam
         exportAllKeys(tempIdentifier)
       );
 
-      wrapModule(reexportModuleName, modules, host);
+      enqueueModule(reexportModuleName);
       return false;
     },
     visitExportNamedDeclaration: function (path: IPath<ESTree.ExportNamedDeclaration>): boolean {
@@ -196,7 +195,7 @@ export function rewriteExportNamedDeclaration(program: ESTree.Program, moduleNam
             ...exports
           );
 
-          wrapModule(reexportModuleName, modules, host);
+          enqueueModule(reexportModuleName);
         } else {
           // e.g. export {a as b};
           const exports = path.node.specifiers

--- a/src/plugins/es6-export.ts
+++ b/src/plugins/es6-export.ts
@@ -101,11 +101,11 @@ function exportAllKeys(identifier: ESTree.Identifier): ESTree.ExpressionStatemen
   );
 }
 
-export function rewriteExportNamedDeclaration(program: ESTree.Program, moduleName: string, host: IHost): void {
+export function rewriteExportNamedDeclaration(program: ESTree.Program, currentModule: string, host: IHost): void {
   visit(program, {
     visitExportAllDeclaration: function(path: IPath<ESTree.ExportAllDeclaration>): boolean {
       // e.g. export * from './a';
-      const reexportModuleName = getModulePath(moduleName, path.node.source.value as string, host);
+      const reexportModuleName = getModulePath(currentModule, path.node.source.value as string, host);
       const reexportModuleIndex = getModuleIndex(reexportModuleName);
 
       const loc = (pos: ESTree.Position) => `${pos.line}_${pos.column}`;
@@ -151,7 +151,7 @@ export function rewriteExportNamedDeclaration(program: ESTree.Program, moduleNam
       } else {
         if (path.node.source) {
           // e.g. export {a as b} from './c';
-          const reexportModuleName = getModulePath(moduleName, path.node.source.value as string, host);
+          const reexportModuleName = getModulePath(currentModule, path.node.source.value as string, host);
           const reexportModuleIndex = getModuleIndex(reexportModuleName);
 
           const loc = (pos: ESTree.Position) => `${pos.line}_${pos.column}`;

--- a/src/plugins/es6-import.ts
+++ b/src/plugins/es6-import.ts
@@ -4,13 +4,13 @@ import { getModuleIndex, enqueueModule } from '../modules';
 import { getModulePath } from '../module-path';
 import { IHost } from '../host';
 
-export function rewriteImportDeclaration(program: ESTree.Program, moduleName: string, host: IHost): void {
+export function rewriteImportDeclaration(program: ESTree.Program, currentModule: string, host: IHost): void {
   visit(program, {
     visitImportDeclaration: function(path: IPath<ESTree.ImportDeclaration>): boolean {
       const source = path.node.source;
 
       if (n.Literal.check(source)) {
-        const importModule = getModulePath(moduleName, source.value as string, host);
+        const importModule = getModulePath(currentModule, source.value as string, host);
         const importModuleIndex = getModuleIndex(importModule);
 
         const loc = (pos: ESTree.Position) => `${pos.line}_${pos.column}`;

--- a/src/plugins/es6-import.ts
+++ b/src/plugins/es6-import.ts
@@ -1,11 +1,10 @@
 import { visit, builders as b, namedTypes as n, IPath } from 'ast-types';
 
-import { getModuleIndex, wrapModule } from '../modules';
+import { getModuleIndex, enqueueModule } from '../modules';
 import { getModulePath } from '../module-path';
 import { IHost } from '../host';
 
-export function rewriteImportDeclaration(program: ESTree.Program, moduleName: string,
-    modules: (ESTree.Expression | ESTree.SpreadElement)[], host: IHost): void {
+export function rewriteImportDeclaration(program: ESTree.Program, moduleName: string, host: IHost): void {
   visit(program, {
     visitImportDeclaration: function(path: IPath<ESTree.ImportDeclaration>): boolean {
       const source = path.node.source;
@@ -77,7 +76,7 @@ export function rewriteImportDeclaration(program: ESTree.Program, moduleName: st
           )
         );
 
-        wrapModule(importModule, modules, host);
+        enqueueModule(importModule);
       }
       return false;
     }

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -1,6 +1,3 @@
-export interface IPlugin {
-  (program: ESTree.Program, moduleName: string, modules: (ESTree.Expression | ESTree.SpreadElement)[]): void;
-}
 export { rewriteImportDeclaration } from './es6-import';
 export { rewriteExportNamedDeclaration } from './es6-export';
 export { rewriteRequireStatements } from './commonjs';

--- a/test/helper.ts
+++ b/test/helper.ts
@@ -9,7 +9,7 @@ import { IHost } from '../src/host';
 export class HostMock implements IHost {
   public pathSep: string = '/';
 
-  private basePath: string = process.cwd()
+  private basePath: string = process.cwd();
   private files: any = {};
 
   constructor(files: {[path: string]: string}, basePath: string = process.cwd()) {

--- a/test/module-path-test.ts
+++ b/test/module-path-test.ts
@@ -70,5 +70,6 @@ test('getModulePath should resolve from node_modules', t => {
   const host = new HostMock({
     'dir/node_modules/mod/index.js': ''
   });
-  t.deepEqual(getModulePath('dir/some/where', 'mod', host), path.resolve(process.cwd(), 'dir/node_modules/mod/index.js'));
+  t.deepEqual(getModulePath('dir/some/where', 'mod', host), path.resolve(process.cwd(),
+    'dir/node_modules/mod/index.js'));
 });

--- a/test/modules-test.ts
+++ b/test/modules-test.ts
@@ -1,7 +1,5 @@
 import test from 'ava';
 
-import { resolve } from 'path';
-
 import { HostMock } from './helper';
 import { getModuleIndex, updateModule, enqueueModule, bundleNextModule, reset } from '../src/modules';
 

--- a/test/modules-test.ts
+++ b/test/modules-test.ts
@@ -3,7 +3,7 @@ import test from 'ava';
 import { resolve } from 'path';
 
 import { HostMock } from './helper';
-import { getModuleIndex, wrapModule, updateModule } from '../src/modules';
+import { getModuleIndex, updateModule, enqueueModule, bundleNextModule } from '../src/modules';
 
 test('getModuleIndex should return a new index per requested file', t => {
   t.deepEqual(getModuleIndex('a/b/c'), 0);
@@ -24,19 +24,28 @@ test.beforeEach(() => {
   updateModule(resolve('some/mod').replace(/\.js$/, ''));
 });
 
-test('wrapModule should wrap a module', t => {
+test('bundleNextModule with empty queue return false', t => {
+  const modules: any[] = [];
+  const plugins = {};
+  const host = new HostMock({});
+
+  t.false(bundleNextModule(modules, host, plugins));
+});
+
+test('bundleNextModule should wrap a module', t => {
   const modules: any[] = [];
   const plugins = {};
   const host = new HostMock({
     'some/mod.js': 'console.log("test");'
   });
 
-  wrapModule('some/mod.js', modules, host, plugins);
+  enqueueModule('some/mod.js');
+  bundleNextModule(modules, host, plugins);
 
   t.deepEqual(Object.keys(modules).length, 1);
 });
 
-test('wrapModule should call all given plugins', t => {
+test('bundleNextModule should call all given plugins', t => {
   const modules: any[] = [];
   let pluginCalls = 0;
   const plugins = {
@@ -47,7 +56,8 @@ test('wrapModule should call all given plugins', t => {
     'some/mod.js': 'console.log("test");'
   });
 
-  wrapModule('some/mod.js', modules, host, plugins);
+  enqueueModule('some/mod.js');
+  bundleNextModule(modules, host, plugins);
 
   t.deepEqual(pluginCalls, 2);
 });

--- a/test/modules-test.ts
+++ b/test/modules-test.ts
@@ -25,7 +25,7 @@ test('getModuleIndex should ignore file extension', t => {
 });
 
 test.beforeEach(() => {
-  updateModule(resolve('some/mod').replace(/\.js$/, ''));
+  updateModule('/some/mod.js');
 });
 
 test('bundleNextModule with empty queue return false', t => {
@@ -64,4 +64,52 @@ test('bundleNextModule should call all given plugins', t => {
   bundleNextModule(modules, host, plugins);
 
   t.deepEqual(pluginCalls, 2);
+});
+
+test('bundleNextModule should not rebundle modules if already up to date', t => {
+  const modules: any[] = [];
+  const plugins = {};
+  const host = new HostMock({
+    'some/mod.js': 'console.log("test");'
+  }, '/');
+
+  enqueueModule('/some/mod.js');
+  bundleNextModule(modules, host, plugins);
+  const firstBundled = modules[0];
+
+  enqueueModule('/some/mod.js');
+  bundleNextModule(modules, host, plugins);
+
+  t.is(modules[0], firstBundled);
+});
+
+test('bundleNextModule should rebundle modules if updated', t => {
+  const modules: any[] = [];
+  const plugins = {};
+  const host = new HostMock({
+    'some/mod.js': 'console.log("test");'
+  }, '/');
+
+  enqueueModule('/some/mod.js');
+  bundleNextModule(modules, host, plugins);
+  const firstBundled = modules[0];
+
+  updateModule('/some/mod.js');
+  enqueueModule('/some/mod.js');
+  bundleNextModule(modules, host, plugins);
+
+  t.not(modules[0], firstBundled);
+});
+
+test('enqueueModule should not accept duplicate entries', t => {
+  const modules: any[] = [];
+  const plugins = {};
+  const host = new HostMock({
+    'some/mod.js': 'console.log("test");'
+  }, '/');
+
+  enqueueModule('/some/mod.js');
+  enqueueModule('/some/mod.js');
+  bundleNextModule(modules, host, plugins);
+  t.false(bundleNextModule(modules, host, plugins));
 });

--- a/test/modules-test.ts
+++ b/test/modules-test.ts
@@ -37,9 +37,9 @@ test('bundleNextModule should wrap a module', t => {
   const plugins = {};
   const host = new HostMock({
     'some/mod.js': 'console.log("test");'
-  });
+  }, '/');
 
-  enqueueModule('some/mod.js');
+  enqueueModule('/some/mod.js');
   bundleNextModule(modules, host, plugins);
 
   t.deepEqual(Object.keys(modules).length, 1);
@@ -53,10 +53,10 @@ test('bundleNextModule should call all given plugins', t => {
     b: function(): void { pluginCalls++; }
   };
   const host = new HostMock({
-    'some/mod.js': 'console.log("test");'
-  });
+    '/some/mod.js': 'console.log("test");'
+  }, '/');
 
-  enqueueModule('some/mod.js');
+  enqueueModule('/some/mod.js');
   bundleNextModule(modules, host, plugins);
 
   t.deepEqual(pluginCalls, 2);

--- a/test/modules-test.ts
+++ b/test/modules-test.ts
@@ -3,7 +3,11 @@ import test from 'ava';
 import { resolve } from 'path';
 
 import { HostMock } from './helper';
-import { getModuleIndex, updateModule, enqueueModule, bundleNextModule } from '../src/modules';
+import { getModuleIndex, updateModule, enqueueModule, bundleNextModule, reset } from '../src/modules';
+
+test.beforeEach(() => {
+  reset();
+});
 
 test('getModuleIndex should return a new index per requested file', t => {
   t.deepEqual(getModuleIndex('a/b/c'), 0);

--- a/test/plugins/commonjs-test.ts
+++ b/test/plugins/commonjs-test.ts
@@ -22,7 +22,7 @@ test('commonjs should rewrite require statements', t => {
   });
 
   const actual = parseAndProcess(input,
-    ast => rewriteRequireStatements(ast, 'name', [], host));
+    ast => rewriteRequireStatements(ast, 'name', host));
 
   t.is(actual, expected);
 });

--- a/test/plugins/es6-export-test.ts
+++ b/test/plugins/es6-export-test.ts
@@ -1,16 +1,15 @@
 import test from 'ava';
 import { stripIndent } from 'common-tags';
 import { HostMock, virtualModule, parseAndProcess } from '../helper';
-import { IHost } from '../../src/host';
 
 import { reset } from '../../src/modules';
 import { rewriteExportNamedDeclaration } from '../../src/plugins/es6-export';
 
-function rewriteExports(input: string, files: any = {}) {
+function rewriteExports(input: string, files: any = {}): string {
   const host = new HostMock(files);
 
   return parseAndProcess(input, ast => {
-    return rewriteExportNamedDeclaration(ast, 'name', [], host);
+    return rewriteExportNamedDeclaration(ast, 'name', host);
   });
 }
 
@@ -31,7 +30,7 @@ test('es6-export plugin should rewrite variable assignment exports correctly', t
     foo: 'bar',
     bar: 'foo'
   };
-  
+
   const actual = executeExports(input);
   t.deepEqual(actual, expected);
 });
@@ -88,7 +87,7 @@ test('es6-export plugin should rewrite named exports correctly', t => {
   const expected = {
     bar: 'foo'
   };
-  
+
   const actual = executeExports(input);
   t.deepEqual(actual, expected);
 });
@@ -103,11 +102,11 @@ test('es6-export plugin should rewrite named reexports correctly', t => {
       foo: 'bar',
     }
   };
-  
+
   const expected = {
     bar: 'bar'
   };
-  
+
   const actual = executeExports(input, {
     'dependency.js': ''
   }, {
@@ -115,7 +114,6 @@ test('es6-export plugin should rewrite named reexports correctly', t => {
   });
   t.deepEqual(actual, expected);
 });
-
 
 test('es6-export plugin should rewrite export-all declarations correctly', t => {
   const input = stripIndent`

--- a/test/plugins/es6-import-test.ts
+++ b/test/plugins/es6-import-test.ts
@@ -1,16 +1,15 @@
 import test from 'ava';
 import { stripIndent } from 'common-tags';
 import { HostMock, virtualModule, parseAndProcess } from '../helper';
-import { IHost } from '../../src/host';
 
 import { reset } from '../../src/modules';
 import { rewriteImportDeclaration } from '../../src/plugins/es6-import';
 
-function rewriteImports(input: string, files: any = {}) {
+function rewriteImports(input: string, files: any = {}): string {
   const host = new HostMock(files);
 
   return parseAndProcess(input, ast => {
-    return rewriteImportDeclaration(ast, 'name', [], host);
+    return rewriteImportDeclaration(ast, 'name', host);
   });
 }
 
@@ -55,7 +54,6 @@ test('es6-import plugin should rewrite import specifiers correctly', t => {
 
   t.deepEqual(actual, expected);
 });
-
 
 test('es6-import plugin should rewrite default import specifiers correctly', t => {
   const input = stripIndent`


### PR DESCRIPTION
A working queue of modules to bundle results in a progress meter of what is already done, but the
future benefit would be to parallelize the module bundling using multiple processes/threads.
