### PR TITLE
feat: specify result for core modules without shim

### DIFF
--- a/src/module-path.ts
+++ b/src/module-path.ts
@@ -36,13 +36,19 @@ function normalizePackage(pkg: IPackage): IPackage {
  * @param filename Path to file from where importPath is resolved
  * @param importIdentifier Identifier to resolve from filename
  * @param [host]
+ * @return either the absolute path to the requested module or undefined for core modules which has no shim
+ * @throws when failing to resolve requested module
  */
 export function getModulePath(filename: string, importIdentifier: string, host: IHost = new DefaultHost()): string {
-  return browserResolveSync(importIdentifier, {
+  const resolvedModulePath = browserResolveSync(importIdentifier, {
     filename: filename,
     modules: nodeCoreLibs,
     packageFilter: normalizePackage,
     readFileSync: (path: string): Buffer => new Buffer(host.readFile(path)),
     isFile: (filePath: string): boolean => host.fileExists(filePath) && host.isFile(filePath)
   });
+  if (resolvedModulePath === importIdentifier && resolvedModulePath.charAt(0) !== '/') {
+    return undefined;
+  }
+  return resolvedModulePath;
 }

--- a/test/module-path-test.ts
+++ b/test/module-path-test.ts
@@ -4,7 +4,7 @@ import test from 'ava';
 import { HostMock } from './helper';
 import { getModulePath } from '../src/module-path';
 
-test('getModulePath should throw no non existing module', t => {
+test('getModulePath should throw on non existing module', t => {
   const host = new HostMock({});
   t.throws(() => getModulePath('some/where', './else', host));
 });
@@ -71,4 +71,9 @@ test('getModulePath should resolve from node_modules', t => {
     'dir/node_modules/mod/index.js': ''
   });
   t.deepEqual(getModulePath('dir/some/where', 'mod', host), path.resolve(process.cwd(), 'dir/node_modules/mod/index.js'));
+});
+
+test('getModulePath should return undefined for core-modules where no shim is available', t => {
+  const host = new HostMock({});
+  t.is(getModulePath('/some/module.js', 'fs', host), undefined);
 });


### PR DESCRIPTION
Our resolution for core modules without shim should return a defined value (not the core module name) so we could identify what to do next.
