### PR TITLE
fix: reverts hack for node core modules

### DIFF
--- a/src/module-path.ts
+++ b/src/module-path.ts
@@ -36,19 +36,15 @@ function normalizePackage(pkg: IPackage): IPackage {
  * @param filename Path to file from where importPath is resolved
  * @param importIdentifier Identifier to resolve from filename
  * @param [host]
- * @return either the absolute path to the requested module or undefined for core modules which has no shim
+ * @return either the absolute path to the requested module or the name of a node core module
  * @throws when failing to resolve requested module
  */
 export function getModulePath(filename: string, importIdentifier: string, host: IHost = new DefaultHost()): string {
-  const resolvedModulePath = browserResolveSync(importIdentifier, {
+  return browserResolveSync(importIdentifier, {
     filename: filename,
     modules: nodeCoreLibs,
     packageFilter: normalizePackage,
     readFileSync: (path: string): Buffer => new Buffer(host.readFile(path)),
     isFile: (filePath: string): boolean => host.fileExists(filePath) && host.isFile(filePath)
   });
-  if (resolvedModulePath === importIdentifier && resolvedModulePath.charAt(0) !== '/') {
-    return undefined;
-  }
-  return resolvedModulePath;
 }

--- a/test/module-path-test.ts
+++ b/test/module-path-test.ts
@@ -74,7 +74,7 @@ test('getModulePath should resolve from node_modules', t => {
     'dir/node_modules/mod/index.js'));
 });
 
-test('getModulePath should return undefined for core-modules where no shim is available', t => {
+test('getModulePath should return the input name for core-modules where no shim is available', t => {
   const host = new HostMock({});
-  t.is(getModulePath('/some/module.js', 'fs', host), undefined);
+  t.is(getModulePath('/some/module.js', 'fs', host), 'fs');
 });


### PR DESCRIPTION
browser resolve should return the core module name if no shim is
available
