### PR TITLE
feat: module wrapper remembers exported state

### DIFF
--- a/typings/ast-types/ast-types.d.ts
+++ b/typings/ast-types/ast-types.d.ts
@@ -53,5 +53,10 @@ declare module 'ast-types' {
     export function blockStatement(body: any[]): ESTree.BlockStatement;
     export function variableDeclaration(kind: 'var'|'let'|'const', declarations: any[]): ESTree.VariableDeclaration;
     export function variableDeclarator(id: any, init?: any): ESTree.VariableDeclarator;
+    export function ifStatement(test: ESTree.Expression, consequent: ESTree.Statement, alternate?: ESTree.Statement): ESTree.IfStatement;
+    export function unaryExpression(operator: ESTree.UnaryOperator, argument: ESTree.Expression): ESTree.UnaryExpression;
+    export function objectExpression(properties: ESTree.Property[]): ESTree.ObjectExpression;
+    export function property(kind: 'init'|'get'|'set', key: ESTree.Literal|ESTree.Identifier, value: ESTree.Expression): ESTree.Property;
+    export function returnStatement(argument?: ESTree.Expression): ESTree.ReturnStatement;
   }
 }


### PR DESCRIPTION
The module wrapper remembers is state now after the module is imported for the first time. This is
required for recursive imports like specified in commonjs.
