### PR TITLE
fix: fixes named default exports

### DIFF
--- a/src/plugins/es6-export.ts
+++ b/src/plugins/es6-export.ts
@@ -235,7 +235,7 @@ export function rewriteExportNamedDeclaration(program: ESTree.Program, currentMo
             b.assignmentExpression(
               '=',
               moduleExportsExpression('default'),
-              b.literal(declaration.id.name)
+              b.identifier(declaration.id.name)
             )
           )
         );

--- a/test/plugins/es6-export-test.ts
+++ b/test/plugins/es6-export-test.ts
@@ -58,25 +58,24 @@ test('es6-export plugin should rewrite anonymous function default export correct
   t.truthy(typeof actual['default'] === 'function');
 });
 
-// Failing
-// test.only('es6-export plugin should rewrite class default export correctly', t => {
-//   const input = stripIndent`
-//     export default class Foo() {}
-//   `;
-//
-//   const actual = executeExports(input);
-//   t.truthy(typeof actual['default'] === 'function');
-// });
+test('es6-export plugin should rewrite class default export correctly', t => {
+  const input = `
+    'use strict';
+    export default class Foo {}
+  `;
 
-// Failing
-// test.only('es6-export plugin should rewrite named function default export correctly', t => {
-//   const input = stripIndent`
-//     export default function foo () {}
-//   `;
-//
-//   const actual = executeExports(input);
-//   t.truthy(typeof actual['default'] === 'function');
-// });
+  const actual = executeExports(input);
+  t.truthy(typeof actual['default'] === 'function');
+});
+
+test('es6-export plugin should rewrite named function default export correctly', t => {
+  const input = stripIndent`
+    export default function foo () {}
+  `;
+
+  const actual = executeExports(input);
+  t.truthy(typeof actual['default'] === 'function');
+});
 
 test('es6-export plugin should rewrite named exports correctly', t => {
   const input = stripIndent`


### PR DESCRIPTION
exports the correct literal (e.g. export default class Foo {} will export Foo)
