### PR TITLE
feat: detects usage of global Buffer

### DIFF
--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -14,7 +14,8 @@ export function bundle(entryPoint: string, host: IHost = new DefaultHost()): str
 
   const detectedGlobals: IDetectedGlobals = {
     global: false,
-    process: false
+    process: false,
+    buffer: false
   };
 
   const paeckchenSource = `

--- a/test/globals-test.ts
+++ b/test/globals-test.ts
@@ -25,15 +25,26 @@ test('injectGlobals should define global if not already in scope', t => {
   const ast = parse(`
     global.check = true;
     process.env.TEST = true;
+    bufferCheck = Buffer.isBuffer;
   `);
 
   injectGlobals({
     global: true,
-    process: true
+    process: true,
+    buffer: true
   }, ast);
 
-  const sandbox: any = {};
+  const sandbox: any = {
+    __paeckchen_require__: function(idx: number): any {
+      return {
+        exports: {
+          isBuffer: function(): void { /*noop*/ }
+        }
+      };
+    }
+  };
   runInNewContext(generate(ast), sandbox);
   t.true(sandbox.global.check);
   t.true(sandbox.process.env.TEST);
+  t.is(typeof sandbox.bufferCheck, 'function');
 });

--- a/test/modules-test.ts
+++ b/test/modules-test.ts
@@ -27,7 +27,8 @@ test('bundleNextModule with empty queue return false', t => {
   const plugins = {};
   const globals = {
     global: false,
-    process: false
+    process: false,
+    buffer: false
   };
   const host = new HostMock({});
 
@@ -39,7 +40,8 @@ test('bundleNextModule should wrap a module', t => {
   const plugins = {};
   const globals = {
     global: false,
-    process: false
+    process: false,
+    buffer: false
   };
   const host = new HostMock({
     'some/mod.js': 'console.log("test");'
@@ -60,7 +62,8 @@ test('bundleNextModule should call all given plugins', t => {
   };
   const globals = {
     global: false,
-    process: false
+    process: false,
+    buffer: false
   };
   const host = new HostMock({
     '/some/mod.js': 'console.log("test");'
@@ -77,7 +80,8 @@ test('bundleNextModule should not rebundle modules if already up to date', t => 
   const plugins = {};
   const globals = {
     global: false,
-    process: false
+    process: false,
+    buffer: false
   };
   const host = new HostMock({
     'some/mod.js': 'console.log("test");'
@@ -98,7 +102,8 @@ test('bundleNextModule should rebundle modules if updated', t => {
   const plugins = {};
   const globals = {
     global: false,
-    process: false
+    process: false,
+    buffer: false
   };
   const host = new HostMock({
     'some/mod.js': 'console.log("test");'
@@ -120,7 +125,8 @@ test('enqueueModule should not accept duplicate entries', t => {
   const plugins = {};
   const globals = {
     global: false,
-    process: false
+    process: false,
+    buffer: false
   };
   const host = new HostMock({
     'some/mod.js': 'console.log("test");'
@@ -137,7 +143,8 @@ test('bundleNextModule should throw if an error occurred', t => {
   const plugins = {};
   const globals = {
     global: false,
-    process: false
+    process: false,
+    buffer: false
   };
   const host = new HostMock({
     '/some/mod.js': '/'
@@ -154,7 +161,8 @@ test('bundleNextModule should bundle an error for unavailable modules', t => {
   const plugins = {};
   const globals = {
     global: false,
-    process: false
+    process: false,
+    buffer: false
   };
   const host = new HostMock({});
 


### PR DESCRIPTION
fixes #35 - in node.js environment Buffer is globaly available. This emulates this behaviour if
there are modules relying on this.
