### PR TITLE
feat: allows aliases to override browser-resolve

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -54,12 +54,9 @@ function getRuntime(input: string): Runtime {
 }
 
 function getAliases(list: string|string[], config: {[name: string]: string}): {[name: string]: string} {
-  let aliases = config;
+  let aliases = config || {};
   if (list && list.length > 0) {
     const split = (alias: string) => alias.split('=');
-    if (!aliases) {
-      aliases = {};
-    }
     if (Array.isArray(list)) {
       aliases = list.reduce((all: any, alias: string) => {
         const [key, path] = split(alias as string);
@@ -71,7 +68,7 @@ function getAliases(list: string|string[], config: {[name: string]: string}): {[
       aliases[key] = path;
     }
   }
-  return aliases || undefined;
+  return aliases;
 }
 
 export function createConfig(options: IBundleOptions, host: IHost): IConfig {

--- a/src/module-path.ts
+++ b/src/module-path.ts
@@ -37,7 +37,11 @@ function normalizePackageFactory(context: IPaeckchenContext): (pkg: IPackage) =>
  * @throws when failing to resolve requested module
  */
 export function getModulePath(filename: string, importIdentifier: string, context: IPaeckchenContext): string {
-  return browserResolveSync(importIdentifier, {
+  let importOrAliasIdentifier = importIdentifier;
+  if (importIdentifier in context.config.aliases) {
+    importOrAliasIdentifier = context.config.aliases[importIdentifier];
+  }
+  return browserResolveSync(importOrAliasIdentifier, {
     filename: filename,
     modules: nodeCoreLibs,
     packageFilter: normalizePackageFactory(context),

--- a/test/config-test.ts
+++ b/test/config-test.ts
@@ -20,7 +20,7 @@ test('createConfig should return the config defaults', t => {
       file: 'paeckchen.js',
       runtime: Runtime.browser
     },
-    aliases: undefined,
+    aliases: {},
     watchMode: false
   } as IConfig);
 });

--- a/test/globals-test.ts
+++ b/test/globals-test.ts
@@ -40,7 +40,7 @@ test('injectGlobals should define global if not already in scope', t => {
     global: true,
     process: true,
     buffer: true
-  }, ast, { config: {} as any, host });
+  }, ast, { config: { aliases: {} } as any, host });
 
   const sandbox: any = {
     console,

--- a/test/module-path-test.ts
+++ b/test/module-path-test.ts
@@ -14,14 +14,16 @@ test('getModulePath should resolve an existing relative file', t => {
   const host = new HostMock({
     'some/else': ''
   });
-  t.is(getModulePath('some/where', './else', { config: {} as any, host }), path.resolve(process.cwd(), 'some/else'));
+  t.is(getModulePath('some/where', './else', { config: { aliases: {} } as any, host }),
+    path.resolve(process.cwd(), 'some/else'));
 });
 
 test('getModulePath should resolve a relative file while adding .js', t => {
   const host = new HostMock({
     'some/else.js': ''
   });
-  t.is(getModulePath('some/where', './else', { config: {} as any, host }), path.resolve(process.cwd(), 'some/else.js'));
+  t.is(getModulePath('some/where', './else', { config: { aliases: {} } as any, host }),
+    path.resolve(process.cwd(), 'some/else.js'));
 });
 
 test('getModulePath should resolve a relative directory with package.json and main', t => {
@@ -29,8 +31,8 @@ test('getModulePath should resolve a relative directory with package.json and ma
     'some/dir/package.json': '{"main": "./main.js"}',
     'some/dir/main.js': ''
   });
-  t.is(getModulePath('some/where', './dir', { config: { input: {} } as any, host }), path.resolve(process.cwd(),
-    'some/dir/main.js'));
+  t.is(getModulePath('some/where', './dir', { config: { input: {},  aliases: {}  } as any, host }),
+    path.resolve(process.cwd(), 'some/dir/main.js'));
 });
 
 test('getModulePath should resolve browser field correctly', t => {
@@ -39,7 +41,7 @@ test('getModulePath should resolve browser field correctly', t => {
     'some/dir/main.js': '',
     'some/dir/browser.js': ''
   });
-  t.is(getModulePath('some/where', './dir', { config: {} as any, host }), path.resolve(process.cwd(),
+  t.is(getModulePath('some/where', './dir', { config: { aliases: {} } as any, host }), path.resolve(process.cwd(),
     'some/dir/browser.js'));
 });
 
@@ -49,8 +51,8 @@ test('getModulePath should resolve jsnext:main field correctly', t => {
     'some/dir/jsnext.js': '',
     'some/dir/main.js': ''
   });
-  t.is(getModulePath('some/where', './dir', { config: { input: {} } as any, host }), path.resolve(process.cwd(),
-    'some/dir/jsnext.js'));
+  t.is(getModulePath('some/where', './dir', { config: { input: {},  aliases: {}  } as any, host }),
+    path.resolve(process.cwd(), 'some/dir/jsnext.js'));
 });
 
 test('getModulePath should not resolve jsnext:main field if source-config is set to es5', t => {
@@ -59,8 +61,8 @@ test('getModulePath should not resolve jsnext:main field if source-config is set
     'some/dir/jsnext.js': '',
     'some/dir/main.js': ''
   });
-  t.is(getModulePath('some/where', './dir', { config: { input: { source: SourceSpec.ES5 } } as any, host }),
-    path.resolve(process.cwd(), 'some/dir/main.js'));
+  t.is(getModulePath('some/where', './dir', { config: { input: { source: SourceSpec.ES5 },  aliases: {}  } as any,
+    host }), path.resolve(process.cwd(), 'some/dir/main.js'));
 });
 
 test('getModulePath should resolve browser, jsnext:main and main in correct precedence', t => {
@@ -70,7 +72,7 @@ test('getModulePath should resolve browser, jsnext:main and main in correct prec
     'some/dir/jsnext.js': '',
     'some/dir/main.js': ''
   });
-  t.is(getModulePath('some/where', './dir', { config: {} as any, host }), path.resolve(process.cwd(),
+  t.is(getModulePath('some/where', './dir', { config: { aliases: {} } as any, host }), path.resolve(process.cwd(),
     'some/dir/browser.js'));
 });
 
@@ -78,19 +80,27 @@ test('getModulePath should resolve a relative directory without package.json but
   const host = new HostMock({
     'some/dir/index.js': ''
   });
-  t.deepEqual(getModulePath('some/where', './dir', { config: {} as any, host }), path.resolve(process.cwd(),
-    'some/dir/index.js'));
+  t.deepEqual(getModulePath('some/where', './dir', { config: { aliases: {} } as any, host }),
+    path.resolve(process.cwd(), 'some/dir/index.js'));
 });
 
 test('getModulePath should resolve from node_modules', t => {
   const host = new HostMock({
     'dir/node_modules/mod/index.js': ''
   });
-  t.deepEqual(getModulePath('dir/some/where', 'mod', { config: {} as any, host }), path.resolve(process.cwd(),
-    'dir/node_modules/mod/index.js'));
+  t.deepEqual(getModulePath('dir/some/where', 'mod', { config: { aliases: {} } as any, host }),
+    path.resolve(process.cwd(), 'dir/node_modules/mod/index.js'));
 });
 
 test('getModulePath should return the core-modules name where no shim is available', t => {
   const host = new HostMock({});
-  t.is(getModulePath('/some/module.js', 'fs', { config: {} as any, host }), 'fs');
+  t.is(getModulePath('/some/module.js', 'fs', { config: { aliases: {} } as any, host }), 'fs');
+});
+
+test('getModulePath should use the alias name if possible', t => {
+  const host = new HostMock({
+    '/alias.js': ''
+  });
+  t.is(getModulePath('/some/module.js', 'alias-module',
+    { config: { aliases: { 'alias-module': '/alias.js' } } as any, host }), '/alias.js');
 });

--- a/test/plugins/commonjs-test.ts
+++ b/test/plugins/commonjs-test.ts
@@ -23,7 +23,9 @@ test('commonjs should rewrite require statements', t => {
 
   const actual = parseAndProcess(input,
     ast => rewriteRequireStatements(ast, 'name', {
-      config: {} as any,
+      config: {
+        aliases: {}
+      } as any,
       host
     }));
 
@@ -44,7 +46,9 @@ test('commonjs should rewrite require statements which are nested inside call ch
 
   const actual = parseAndProcess(input,
     ast => rewriteRequireStatements(ast, 'name', {
-      config: {} as any,
+      config: {
+        aliases: {}
+      } as any,
       host
     }));
 

--- a/test/plugins/es6-export-test.ts
+++ b/test/plugins/es6-export-test.ts
@@ -10,7 +10,9 @@ function rewriteExports(input: string, files: any = {}): string {
 
   return parseAndProcess(input, ast => {
     return rewriteExportNamedDeclaration(ast, 'name', {
-      config: {} as any,
+      config: {
+        aliases: {}
+      } as any,
       host
     });
   });

--- a/test/plugins/es6-import-test.ts
+++ b/test/plugins/es6-import-test.ts
@@ -10,7 +10,9 @@ function rewriteImports(input: string, files: any = {}): string {
 
   return parseAndProcess(input, ast => {
     return rewriteImportDeclaration(ast, 'name', {
-      config: {} as any,
+      config: {
+        aliases: {}
+      } as any,
       host
     });
   });


### PR DESCRIPTION
implements #69 - before calling browser-resolve we replace the module-id with the alias
