### PR TITLE
refactor(paeckchen-core): bundle does not return

### DIFF
--- a/packages/paeckchen-cli/src/index.ts
+++ b/packages/paeckchen-cli/src/index.ts
@@ -1,12 +1,19 @@
 #!/usr/bin/env node
 
+import { join } from 'path';
 import { createOptions } from './options';
-import { bundle } from 'paeckchen-core';
+import { bundle, DefaultHost, IPaeckchenContext } from 'paeckchen-core';
 
 const startTime = new Date().getTime();
-const result = bundle(createOptions(process.argv));
-if (result) {
-  process.stdout.write(result);
-}
-const endTime = new Date().getTime();
-process.stderr.write(`Bundeling took ${(endTime - startTime) / 1000}s\n`);
+const options = createOptions(process.argv);
+bundle(options, new DefaultHost(), (result: string, context: IPaeckchenContext) => {
+  if (result) {
+    if (options.outputFile) {
+      context.host.writeFile(join(context.config.output.folder, context.config.output.file), result);
+    } else {
+      process.stdout.write(result);
+    }
+  }
+  const endTime = new Date().getTime();
+  process.stderr.write(`Bundeling took ${(endTime - startTime) / 1000}s\n`);
+});

--- a/packages/paeckchen-core/src/bundle.ts
+++ b/packages/paeckchen-core/src/bundle.ts
@@ -56,7 +56,7 @@ const paeckchenSource = `
 
 export type BundlingFunction = typeof executeBundling;
 export function executeBundling(state: State, paeckchenAst: ESTree.Program, context: IPaeckchenContext,
-    outputFunction: OutputFunction): string {
+    outputFunction: OutputFunction): void {
   while (bundleNextModule(state, context)) {
     process.stderr.write('.');
   }
@@ -70,7 +70,6 @@ export function executeBundling(state: State, paeckchenAst: ESTree.Program, cont
     comment: true
   });
   outputFunction(bundleResult, context);
-  return bundleResult;
 }
 
 export type RebundleFactory = typeof rebundleFactory;
@@ -99,7 +98,7 @@ export function writeOutput(bundleResult: string, context: IPaeckchenContext): v
 export function bundle(options: IBundleOptions, host: IHost = new DefaultHost(),
     outputFunction: OutputFunction = writeOutput,
       bundleFunction: BundlingFunction = executeBundling,
-        rebundleFactoryFunction: RebundleFactory = rebundleFactory): string {
+        rebundleFactoryFunction: RebundleFactory = rebundleFactory): void {
   const context: IPaeckchenContext = {
     config: createConfig(options, host),
     host
@@ -121,5 +120,5 @@ export function bundle(options: IBundleOptions, host: IHost = new DefaultHost(),
     context.rebundle = rebundleFactoryFunction(state, paeckchenAst, context, bundleFunction, outputFunction);
   }
 
-  return bundleFunction(state, paeckchenAst, context, outputFunction);
+  bundleFunction(state, paeckchenAst, context, outputFunction);
 }

--- a/packages/paeckchen-core/src/config.ts
+++ b/packages/paeckchen-core/src/config.ts
@@ -93,7 +93,7 @@ export function createConfig(options: IBundleOptions, host: IHost): IConfig {
   config.output = undefined;
   config.output = {} as any;
   config.output.folder = options.outputDirectory || configFile.output && configFile.output.folder || host.cwd();
-  config.output.file = options.outputFile || configFile.output && configFile.output.file || undefined;
+  config.output.file = options.outputFile || configFile.output && configFile.output.file || 'paeckchen.js';
   config.output.runtime = getRuntime(options.runtime || configFile.output && configFile.output.runtime || 'browser');
   config.aliases = processKeyValueOption<string>(options.alias, configFile.aliases);
   config.externals = processKeyValueOption<string|boolean>(options.external, configFile.externals);

--- a/packages/paeckchen-core/test/bundle-test.ts
+++ b/packages/paeckchen-core/test/bundle-test.ts
@@ -17,7 +17,8 @@ test('bundle should bundle the given entry-point and its dependencies', t => {
     `
   });
 
-  const bundled = bundle({entryPoint: 'entry-point.js'}, host);
+  let bundled: string;
+  bundle({entryPoint: 'entry-point.js'}, host, result => bundled = result);
 
   let called = false;
   virtualModule(bundled, {
@@ -46,7 +47,8 @@ test('bundle should bundle global dependencies', t => {
     alias: 'buffer=/BUFFER'
   };
 
-  const bundled = bundle(config, host);
+  let bundled: string;
+  bundle(config, host, result => bundled = result);
 
   let called = false;
   virtualModule(bundled, {
@@ -69,7 +71,8 @@ test('bundle should check for a config-file', t => {
       })
   }, '/');
 
-  const bundled = bundle({}, host);
+  let bundled: string;
+  bundle({}, host, result => bundled = result);
 
   let called = false;
   virtualModule(bundled, {

--- a/packages/paeckchen-core/test/config-test.ts
+++ b/packages/paeckchen-core/test/config-test.ts
@@ -17,7 +17,7 @@ test('createConfig should return the config defaults', t => {
     },
     output: {
       folder: host.cwd(),
-      file: undefined,
+      file: 'paeckchen.js',
       runtime: Runtime.browser
     },
     aliases: {},


### PR DESCRIPTION
The bundle function does not return anymore.
This reduces the api surface and prepares for future
asyncronous bundling.
