### PR TITLE
fix(paeckchen-core): paeckchen default to output bundle to stdout

### DIFF
--- a/packages/paeckchen-core/src/config.ts
+++ b/packages/paeckchen-core/src/config.ts
@@ -93,7 +93,7 @@ export function createConfig(options: IBundleOptions, host: IHost): IConfig {
   config.output = undefined;
   config.output = {} as any;
   config.output.folder = options.outputDirectory || configFile.output && configFile.output.folder || host.cwd();
-  config.output.file = options.outputFile || configFile.output && configFile.output.file || 'paeckchen.js';
+  config.output.file = options.outputFile || configFile.output && configFile.output.file || undefined;
   config.output.runtime = getRuntime(options.runtime || configFile.output && configFile.output.runtime || 'browser');
   config.aliases = processKeyValueOption<string>(options.alias, configFile.aliases);
   config.externals = processKeyValueOption<string|boolean>(options.external, configFile.externals);

--- a/packages/paeckchen-core/test/config-test.ts
+++ b/packages/paeckchen-core/test/config-test.ts
@@ -17,7 +17,7 @@ test('createConfig should return the config defaults', t => {
     },
     output: {
       folder: host.cwd(),
-      file: 'paeckchen.js',
+      file: undefined,
       runtime: Runtime.browser
     },
     aliases: {},


### PR DESCRIPTION
By default paeckchen should write the bundle result to stdout instead of a file

ISSUES CLOSED: #117
