### PR TITLE
fix(paeckchen-cli): respect context.config

### DIFF
--- a/packages/paeckchen-cli/src/index.ts
+++ b/packages/paeckchen-cli/src/index.ts
@@ -5,10 +5,9 @@ import { createOptions } from './options';
 import { bundle, DefaultHost, IPaeckchenContext } from 'paeckchen-core';
 
 const startTime = new Date().getTime();
-const options = createOptions(process.argv);
-bundle(options, new DefaultHost(), (result: string, context: IPaeckchenContext) => {
+bundle(createOptions(process.argv), new DefaultHost(), (result: string, context: IPaeckchenContext) => {
   if (result) {
-    if (options.outputFile) {
+    if (context.config.output.file) {
       context.host.writeFile(join(context.config.output.folder, context.config.output.file), result);
     } else {
       process.stdout.write(result);

--- a/packages/paeckchen-core/src/config.ts
+++ b/packages/paeckchen-core/src/config.ts
@@ -93,7 +93,7 @@ export function createConfig(options: IBundleOptions, host: IHost): IConfig {
   config.output = undefined;
   config.output = {} as any;
   config.output.folder = options.outputDirectory || configFile.output && configFile.output.folder || host.cwd();
-  config.output.file = options.outputFile || configFile.output && configFile.output.file || 'paeckchen.js';
+  config.output.file = options.outputFile || configFile.output && configFile.output.file || undefined;
   config.output.runtime = getRuntime(options.runtime || configFile.output && configFile.output.runtime || 'browser');
   config.aliases = processKeyValueOption<string>(options.alias, configFile.aliases);
   config.externals = processKeyValueOption<string|boolean>(options.external, configFile.externals);

--- a/packages/paeckchen-core/test/config-test.ts
+++ b/packages/paeckchen-core/test/config-test.ts
@@ -17,7 +17,7 @@ test('createConfig should return the config defaults', t => {
     },
     output: {
       folder: host.cwd(),
-      file: 'paeckchen.js',
+      file: undefined,
       runtime: Runtime.browser
     },
     aliases: {},


### PR DESCRIPTION
the cli should use the context.config instead of the created own config,
because the core will extend the configuration with the config file
settings and defaults

ISSUES CLOSED: #117
