### PR TITLE
fix(paeckchen-cli): respect context.config

### DIFF
--- a/packages/paeckchen-cli/src/index.ts
+++ b/packages/paeckchen-cli/src/index.ts
@@ -5,10 +5,9 @@ import { createOptions } from './options';
 import { bundle, DefaultHost, IPaeckchenContext } from 'paeckchen-core';
 
 const startTime = new Date().getTime();
-const options = createOptions(process.argv);
-bundle(options, new DefaultHost(), (result: string, context: IPaeckchenContext) => {
+bundle(createOptions(process.argv), new DefaultHost(), (result: string, context: IPaeckchenContext) => {
   if (result) {
-    if (options.outputFile) {
+    if (context.config.output.file) {
       context.host.writeFile(join(context.config.output.folder, context.config.output.file), result);
     } else {
       process.stdout.write(result);


### PR DESCRIPTION
the cli should use the context.config instead of the created own config, because the core will
extend the configuration with the config file settings and defaults

ISSUES CLOSED: #117
