### PR TITLE
perf(paeckchen-core): stop early processing es2015 modules

### DIFF
--- a/packages/paeckchen-core/src/plugins/es6-export.ts
+++ b/packages/paeckchen-core/src/plugins/es6-export.ts
@@ -250,6 +250,11 @@ export function rewriteExportNamedDeclaration(program: ESTree.Program, currentMo
         );
       }
       return false;
+    },
+    visitStatement: function(path: IPath<ESTree.Statement>): boolean {
+      // es2015 exports are only allowed at the top level of a module
+      // => we could stop here
+      return false;
     }
   });
 }

--- a/packages/paeckchen-core/src/plugins/es6-import.ts
+++ b/packages/paeckchen-core/src/plugins/es6-import.ts
@@ -79,6 +79,11 @@ export function rewriteImportDeclaration(program: ESTree.Program, currentModule:
         enqueueModule(importModule);
       }
       return false;
+    },
+    visitStatement: function(path: IPath<ESTree.Statement>): boolean {
+      // es2015 imports are only allowed at the top level of a module
+      // => we could stop here
+      return false;
     }
   });
 }


### PR DESCRIPTION
since es2015 modules are only allowed at top level (AST) we should only traverse the first ast level
