### PR TITLE
refactor(paeckchen-core): change error handling

### DIFF
--- a/packages/paeckchen-cli/src/index.ts
+++ b/packages/paeckchen-cli/src/index.ts
@@ -22,24 +22,22 @@ bundle(options, new DefaultHost(), (error, context, code, sourceMap) => {
     if (context && !context.config.watchMode) {
       process.exit(1);
     }
-    return;
-  }
-  if (code) {
+  } else {
     if (context && context.config.output.file) {
       const bundleName = join(context.config.output.folder, context.config.output.file);
       const mapName = bundleName + '.map';
       if (sourceMap) {
         if (context.config.output.sourceMap === 'inline') {
-          context.host.writeFile(bundleName, appendSourceMap(code, sourceMap));
+          context.host.writeFile(bundleName, appendSourceMap(code as string, sourceMap));
         } else {
           context.host.writeFile(bundleName, code + sourceMappingURL + basename(mapName));
           context.host.writeFile(mapName, sourceMap);
         }
       } else {
-        context.host.writeFile(bundleName, code);
+        context.host.writeFile(bundleName, code as string);
       }
     } else {
-      let output = code;
+      let output = code as string;
       if (sourceMap) {
         output = appendSourceMap(output, sourceMap);
       }

--- a/packages/paeckchen-core/test/bundle-test.ts
+++ b/packages/paeckchen-core/test/bundle-test.ts
@@ -274,3 +274,27 @@ test.cb('bundle should restart from cache if available', t => {
 
   bundle(config, host, outputFunction, bundleFunction);
 });
+
+test.cb('bundle should throw if error during setup', t => {
+  const host = new HostMock({
+    'main.js': ''
+  });
+  const config: BundleOptions = {
+    entryPoint: './main.js',
+    debug: true,
+    watchMode: true
+  };
+  const outputFunction = (error: Error|null) => {
+    if (error) {
+      t.regex(error.message, /Failure/);
+    } else {
+      t.fail('expected error');
+    }
+    t.end();
+  };
+  const bundleFunction = (state: State, paeckchenAst: ESTree.Program, context: PaeckchenContext) => undefined;
+
+  bundle(config, host, outputFunction, bundleFunction, () => {
+    throw new Error('Failure');
+  });
+});


### PR DESCRIPTION
Errors are not thrown to the result promise anymore. Instead the output function looks more like a
nodeback which receives any error as first parameter or null. This is a lot easier to handle.
