### PR TITLE
refactor(paeckchen-core): move watcher creation into host

### DIFF
--- a/packages/paeckchen-core/src/bundle.ts
+++ b/packages/paeckchen-core/src/bundle.ts
@@ -169,7 +169,7 @@ function createContext(config: Config, host: Host, options: BundleOptions): Paec
     throw new Error('Missing entry-point');
   }
   if (context.config.watchMode) {
-    context.watcher = new Watcher();
+    context.watcher = host.createWatcher && host.createWatcher() || new Watcher();
   }
   return context;
 }

--- a/packages/paeckchen-core/src/host.ts
+++ b/packages/paeckchen-core/src/host.ts
@@ -1,4 +1,5 @@
 import { existsSync, readFile, writeFileSync, stat } from 'fs';
+import { Watcher } from './watcher';
 
 export interface Host {
   cwd(): string;
@@ -7,6 +8,7 @@ export interface Host {
   readFile(path: string): Promise<string>;
   writeFile(path: string, content: string): void;
   getModificationTime(path: string): Promise<number>;
+  createWatcher?(): Watcher;
 }
 
 export class DefaultHost implements Host {
@@ -53,6 +55,10 @@ export class DefaultHost implements Host {
         resolve(stats.mtime.getTime());
       });
     });
+  }
+
+  public createWatcher(): Watcher {
+    return new Watcher();
   }
 
 }

--- a/packages/paeckchen-core/test/helper.ts
+++ b/packages/paeckchen-core/test/helper.ts
@@ -5,6 +5,8 @@ import { generate as escodegenGenerate } from 'escodegen';
 import { merge } from 'lodash';
 import { oneLine } from 'common-tags';
 import { Host } from '../src/host';
+import { Watcher } from '../src/watcher';
+import { ChokidarMock } from './watcher-test';
 
 export const errorLogger = {
   configure: () => undefined,
@@ -69,6 +71,10 @@ export class HostMock implements Host {
 
   public getModificationTime(path: string): Promise<number> {
     return Promise.resolve(0);
+  }
+
+  public createWatcher(): Watcher {
+    return new Watcher(new ChokidarMock());
   }
 
 }

--- a/packages/paeckchen-core/test/host-test.ts
+++ b/packages/paeckchen-core/test/host-test.ts
@@ -1,6 +1,7 @@
 import test from 'ava';
 import { resolve } from 'path';
 import { writeFile, readFileSync, existsSync, unlinkSync, unlink } from 'fs';
+import { Watcher } from '../src/watcher';
 
 import { DefaultHost } from '../src/host';
 
@@ -124,4 +125,9 @@ test('DefaultHost#getModificationTime should return -1 if file does not exist', 
     .then(mtime => {
       t.is(mtime, -1);
     });
+});
+
+test('DefaultHost#createWatcher should return a new watcher instance', t => {
+  const watcher = (t.context.host as DefaultHost).createWatcher();
+  t.true(watcher instanceof Watcher);
 });


### PR DESCRIPTION
Move watcher creation into host for supply paeckchen with a custom watcher. For example a custom
filesystem like vinyl-fs could be used for update the watcher status.

ISSUES CLOSED: #185
