### PR TITLE
refactor(paeckchen-core): expose watcher interface

### DIFF
--- a/packages/paeckchen-core/src/bundle.ts
+++ b/packages/paeckchen-core/src/bundle.ts
@@ -9,7 +9,7 @@ import { enqueueModule, bundleNextModules } from './modules';
 import { injectGlobals } from './globals';
 import { createConfig, Config } from './config';
 import { State } from './state';
-import { Watcher } from './watcher';
+import { Watcher, FSWatcher } from './watcher';
 import { ProgressStep, Logger, NoopLogger } from './logger';
 import { updateCache, readCache } from './cache';
 
@@ -169,7 +169,7 @@ function createContext(config: Config, host: Host, options: BundleOptions): Paec
     throw new Error('Missing entry-point');
   }
   if (context.config.watchMode) {
-    context.watcher = host.createWatcher && host.createWatcher() || new Watcher();
+    context.watcher = host.createWatcher && host.createWatcher() || new FSWatcher();
   }
   return context;
 }
@@ -186,7 +186,6 @@ export function bundle(options: BundleOptions, host: Host = new DefaultHost(), o
           const state = new State(getModules(paeckchenAst).elements);
           if (cache.state) {
             return state.load(context, cache.state)
-              .then(() => ({ paeckchenAst, state }))
               .then(() => {
                 if (context.config.watchMode) {
                   Object.keys(state.wrappedModules).forEach(file => {

--- a/packages/paeckchen-core/src/host.ts
+++ b/packages/paeckchen-core/src/host.ts
@@ -1,5 +1,5 @@
 import { existsSync, readFile, writeFileSync, stat } from 'fs';
-import { Watcher } from './watcher';
+import { Watcher, FSWatcher } from './watcher';
 
 export interface Host {
   cwd(): string;
@@ -58,7 +58,7 @@ export class DefaultHost implements Host {
   }
 
   public createWatcher(): Watcher {
-    return new Watcher();
+    return new FSWatcher();
   }
 
 }

--- a/packages/paeckchen-core/src/index.ts
+++ b/packages/paeckchen-core/src/index.ts
@@ -19,3 +19,6 @@ export {
   Config,
   LogLevel
 } from './config';
+export {
+  Watcher
+} from './watcher';

--- a/packages/paeckchen-core/src/modules.ts
+++ b/packages/paeckchen-core/src/modules.ts
@@ -110,11 +110,8 @@ function watchModule(state: State, modulePath: string, context: PaeckchenContext
 }
 
 function wrapModule(modulePath: string, state: State, context: PaeckchenContext, plugins: any): Promise<void> {
-  context.logger.trace('module', `wrapModule abc [modulePath=${modulePath}]`);
+  context.logger.trace('module', `wrapModule [modulePath=${modulePath}]`);
   return Promise.resolve()
-    .then(() => {
-      context.logger.trace('module', `wrapModule [modulePath=${modulePath}]`);
-    })
     .then(() => {
       // Prefill index
       getModuleIndex(modulePath, state);
@@ -153,6 +150,8 @@ function wrapModule(modulePath: string, state: State, context: PaeckchenContext,
             context.logger.error('module', e, `Failed to process module '${modulePath}'`);
             throw e;
           });
+      } else {
+        context.logger.trace('module', `wrapModule; upToDate [modulePath=${modulePath}]`);
       }
       return undefined;
     });

--- a/packages/paeckchen-core/src/watcher.ts
+++ b/packages/paeckchen-core/src/watcher.ts
@@ -1,18 +1,56 @@
 import { dirname } from 'path';
-import { FSWatcher } from 'chokidar';
+import { FSWatcher as Chokidar } from 'chokidar';
 
 type FileMap = { [name: string]: boolean };
 type WatcherMap = { [name: string]: number };
 
-export class Watcher {
+/**
+ * Watcher interface.
+ *
+ * This is the API paeckchen uses to register watch tasks on used modules and unregisters them on deletion.
+ */
+export interface Watcher {
 
-  private watcher: FSWatcher;
+  /**
+   * This callback is being called whenever a watched file receives some sort of update.
+   *
+   * @callback Watcher.updateHandler
+   * @param {string} event - The event name (must be either 'add', 'update' or 'remove')
+   * @param {string} fileName - The absolute path to the watched file in this event
+   */
+
+  /**
+   * Called by paeckchen to start the first watch task.
+   * This is only called once per paeckchen instance.
+   *
+   * @param {Watcher.updateHandler} updateHandler
+   */
+  start(updateHandler: (event: string, fileName: string) => void): void;
+
+  /**
+   * This is called by paeckchen to register a new file to watch.
+   *
+   * @param {string} fileName - The absolute file path to watch
+   */
+  watchFile(fileName: string): void;
+
+  /**
+   * This is called by paeckchen to unregister a file currently watched.
+   *
+   * @param {string} fileName - The absolute file path to unwatch
+   */
+  unwatchFile(fileName: string): void;
+}
+
+export class FSWatcher implements Watcher {
+
+  private watcher: Chokidar;
 
   private watchers: WatcherMap = {};
 
   private files: FileMap = {};
 
-  constructor(watcher: FSWatcher = new FSWatcher()) {
+  constructor(watcher: Chokidar = new Chokidar()) {
     this.watcher = watcher;
   }
 

--- a/packages/paeckchen-core/test/helper.ts
+++ b/packages/paeckchen-core/test/helper.ts
@@ -5,7 +5,7 @@ import { generate as escodegenGenerate } from 'escodegen';
 import { merge } from 'lodash';
 import { oneLine } from 'common-tags';
 import { Host } from '../src/host';
-import { Watcher } from '../src/watcher';
+import { FSWatcher } from '../src/watcher';
 import { ChokidarMock } from './watcher-test';
 
 export const errorLogger = {
@@ -73,8 +73,8 @@ export class HostMock implements Host {
     return Promise.resolve(0);
   }
 
-  public createWatcher(): Watcher {
-    return new Watcher(new ChokidarMock());
+  public createWatcher(): FSWatcher {
+    return new FSWatcher(new ChokidarMock());
   }
 
 }

--- a/packages/paeckchen-core/test/host-test.ts
+++ b/packages/paeckchen-core/test/host-test.ts
@@ -1,7 +1,7 @@
 import test from 'ava';
 import { resolve } from 'path';
 import { writeFile, readFileSync, existsSync, unlinkSync, unlink } from 'fs';
-import { Watcher } from '../src/watcher';
+import { FSWatcher } from '../src/watcher';
 
 import { DefaultHost } from '../src/host';
 
@@ -129,5 +129,5 @@ test('DefaultHost#getModificationTime should return -1 if file does not exist', 
 
 test('DefaultHost#createWatcher should return a new watcher instance', t => {
   const watcher = (t.context.host as DefaultHost).createWatcher();
-  t.true(watcher instanceof Watcher);
+  t.true(watcher instanceof FSWatcher);
 });

--- a/packages/paeckchen-core/test/watcher-test.ts
+++ b/packages/paeckchen-core/test/watcher-test.ts
@@ -1,9 +1,9 @@
 import test from 'ava';
-import { FSWatcher } from 'chokidar';
+import { FSWatcher as Chokidar } from 'chokidar';
 
-import { Watcher } from '../src/watcher';
+import { FSWatcher as DefaultWatcher } from '../src/watcher';
 
-export class ChokidarMock extends FSWatcher {
+export class ChokidarMock extends Chokidar {
   public onCalls: string[] = [];
   private onAdd: Function;
   private onChange: Function;
@@ -48,7 +48,7 @@ test('Watcher should register callbacks on the watcher if enabled', t => {
   const chokidar = new ChokidarMock();
   const onUpdate = (event: string, fileName: string): void => undefined;
 
-  const watcher = new Watcher(chokidar);
+  const watcher = new DefaultWatcher(chokidar);
   watcher.start(onUpdate);
 
   t.deepEqual(chokidar.onCalls, ['add', 'change', 'unlink']);
@@ -62,7 +62,7 @@ test('Watcher should ignore changes of new files not on the watch list', t => {
     updateFileName = fileName;
   };
 
-  const watcher = new Watcher(chokidar);
+  const watcher = new DefaultWatcher(chokidar);
   watcher.start(onUpdate);
   chokidar.emit('add', 'new-file');
 
@@ -77,7 +77,7 @@ test('Watcher should ignore changes of existing files not on the watch list', t 
     updateFileName = fileName;
   };
 
-  const watcher = new Watcher(chokidar);
+  const watcher = new DefaultWatcher(chokidar);
   watcher.start(onUpdate);
   chokidar.emit('change', 'changed-file');
 
@@ -92,7 +92,7 @@ test('Watcher should ignore removals of existing files not on the watch list', t
     updateFileName = fileName;
   };
 
-  const watcher = new Watcher(chokidar);
+  const watcher = new DefaultWatcher(chokidar);
   watcher.start(onUpdate);
   chokidar.emit('unlink', 'removed-file');
 
@@ -107,7 +107,7 @@ test('Watcher should register folders with new files to the watcher', t => {
     updateFileName = fileName;
   };
 
-  const watcher = new Watcher(chokidar);
+  const watcher = new DefaultWatcher(chokidar);
   watcher.start(onUpdate);
   watcher.watchFile('dir/new-file');
 
@@ -122,7 +122,7 @@ test('Watcher should remove folders from the watcher if no watched files left', 
     updateFileName = fileName;
   };
 
-  const watcher = new Watcher(chokidar);
+  const watcher = new DefaultWatcher(chokidar);
   watcher.start(onUpdate);
   watcher.watchFile('dir/file');
   watcher.unwatchFile('dir/file');
@@ -138,7 +138,7 @@ test('Watcher should keep watching folders if watched files left', t => {
     updateFileName = fileName;
   };
 
-  const watcher = new Watcher(chokidar);
+  const watcher = new DefaultWatcher(chokidar);
   watcher.start(onUpdate);
   watcher.watchFile('dir/file1');
   watcher.watchFile('dir/file2');
@@ -156,7 +156,7 @@ test('Watcher should notify if watched file changes', t => {
   };
   const chokidar = new ChokidarMock();
 
-  const watcher = new Watcher(chokidar);
+  const watcher = new DefaultWatcher(chokidar);
   watcher.start(onUpdate);
   watcher.watchFile('dir/file');
   chokidar.emit('change', 'dir/file');
@@ -174,7 +174,7 @@ test('Watcher should notify if watched file is added', t => {
   };
   const chokidar = new ChokidarMock();
 
-  const watcher = new Watcher(chokidar);
+  const watcher = new DefaultWatcher(chokidar);
   watcher.start(onAdd);
   watcher.watchFile('dir/file');
   chokidar.emit('add', 'dir/file');


### PR DESCRIPTION
This exposes the watcher interface to be implemented by custom watchers

Relates to #186 
