### PR TITLE
fix(paeckchen-core): write source-map with correct name and path

### DIFF
--- a/packages/paeckchen-core/test/bundle-test.ts
+++ b/packages/paeckchen-core/test/bundle-test.ts
@@ -181,7 +181,7 @@ test.cb('bundle should create a watch and a rebundle function when in watch mode
 });
 
 test.cb('bundle with source maps should add mappings via sorcery', t => {
-  const paths = (list: string[]) => list.map(entry => entry.replace('\\', '/'));
+  const paths = (list: string[]) => list.map(entry => entry.replace(/\\/g, '/'));
 
   const config: BundleOptions = {
     entryPoint: './fixtures/main.js',

--- a/packages/paeckchen-core/test/bundle-test.ts
+++ b/packages/paeckchen-core/test/bundle-test.ts
@@ -181,6 +181,8 @@ test.cb('bundle should create a watch and a rebundle function when in watch mode
 });
 
 test.cb('bundle with source maps should add mappings via sorcery', t => {
+  const paths = (list: string[]) => list.map(entry => entry.replace('\\', '/'));
+
   const config: BundleOptions = {
     entryPoint: './fixtures/main.js',
     sourceMap: true
@@ -194,7 +196,7 @@ test.cb('bundle with source maps should add mappings via sorcery', t => {
     const sourceMap = JSON.parse(_sourceMap as string);
 
     t.not(code, undefined);
-    t.deepEqual(sourceMap.sources, ['../../test/fixtures/main.ts']);
+    t.deepEqual(paths(sourceMap.sources), ['../../test/fixtures/main.ts']);
     t.truthy((sourceMap.sourcesContent[0] as string).match(/: string/));
     t.end();
   });


### PR DESCRIPTION
the bundle name (if available) must be set in the source-map as well as all sources should be
relative to the host cwd.
