### PR TITLE
fix(paeckchen-core): reduce workload per turnaround

### DIFF
--- a/packages/paeckchen-core/src/modules.ts
+++ b/packages/paeckchen-core/src/modules.ts
@@ -67,7 +67,7 @@ export function bundleNextModules(state: State, context: PaeckchenContext,
   if (state.moduleBundleQueue.length === 0) {
     return [];
   }
-  const modules = state.moduleBundleQueue.splice(0);
+  const modules = state.moduleBundleQueue.splice(0, 4);
   return modules.map(modulePath => {
     context.logger.debug('module', `bundle ${modulePath}`);
     return watchModule(state, modulePath, context)


### PR DESCRIPTION
Only bundling 4 modules per turnaround will reduce the workload during bundling. This leads to far
more reponse UIs.

ISSUES CLOSED: #255
