### PR TITLE
feat(paeckchen-core): host creates parent folders

### DIFF
--- a/packages/paeckchen-core/package.json
+++ b/packages/paeckchen-core/package.json
@@ -41,6 +41,7 @@
   "devDependencies": {
     "@types/common-tags": "1.2.3",
     "@types/lodash": "4.14.34",
+    "@types/mkdirp": "0.3.29",
     "@types/node": "4.0.30",
     "ava": "0.16.0",
     "common-tags": "1.3.1",
@@ -61,6 +62,7 @@
     "browser-resolve": "1.11.2",
     "chokidar": "1.6.0",
     "escodegen": "1.8.1",
+    "mkdirp": "0.5.1",
     "node-libs-browser": "1.0.0",
     "paeckchen-sorcery": "0.1.1"
   },

--- a/packages/paeckchen-core/src/host.ts
+++ b/packages/paeckchen-core/src/host.ts
@@ -1,5 +1,7 @@
 import { existsSync, readFile, writeFileSync, stat } from 'fs';
+import { dirname } from 'path';
 import { Watcher, FSWatcher } from './watcher';
+import * as mkdirp from 'mkdirp';
 
 export interface Host {
   cwd(): string;
@@ -43,6 +45,7 @@ export class DefaultHost implements Host {
   }
 
   public writeFile(path: string, content: string): void {
+    mkdirp.sync(dirname(path));
     writeFileSync(path, content);
   }
 

--- a/packages/paeckchen-core/test/host-test.ts
+++ b/packages/paeckchen-core/test/host-test.ts
@@ -65,7 +65,7 @@ test('DefaultHost#readFile should fail for non existing file', t => {
 });
 
 test('DefaultHost#writeFile should dump the content to disk', t => {
-  const file = resolve(process.cwd(), 'dump.txt');
+  const file = resolve(process.cwd(), 'create-me/dump.txt');
   try {
     (t.context.host as DefaultHost).writeFile(file, 'test-data');
     t.is(readFileSync(file).toString(), 'test-data');


### PR DESCRIPTION
When writing files paeckchen should create parent folders if required.

ISSUES CLOSED: #268
